### PR TITLE
TA#36017 Fix domain filters when clicking on stock moves

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     volumes:
       - odoo-web-data:/var/lib/odoo
       - ./.log:/var/log/odoo
-      - ./vue_stock_forecast:/mnt/extra-addons/vue_stock_forecast
     ports:
       - "8069:8069"
       - "8071:8071"

--- a/vue_stock_forecast/__manifest__.py
+++ b/vue_stock_forecast/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Vue Stock Forecast",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "author": "Numigi",
     "maintainer": "Numigi",
     "website": "https://bit.ly/numigi-com",

--- a/vue_stock_forecast/static/dist/vueStockForecast.js
+++ b/vue_stock_forecast/static/dist/vueStockForecast.js
@@ -416,10 +416,10 @@ exports.default = {
             var outgoingQty = row.outgoing.filter(movesBeforeDate).reduce(stockMoveSum, 0);
             var stockAtDate = row.currentStock + incomingQty - outgoingQty;
 
-            var dateFrom = moment(dateTo).subtract(1, this.dateGroupBy).format("YYYY-MM-DD");
+            var dateFrom = this.getDateFrom(dateTo);
 
             function movesAtDate(move) {
-                return dateFrom < move.date && move.date <= dateTo;
+                return dateFrom <= move.date && move.date <= dateTo;
             }
             var incomingQtyAtDate = row.incoming.filter(movesAtDate).reduce(stockMoveSum, 0);
             var outgoingQtyAtDate = row.outgoing.filter(movesAtDate).reduce(stockMoveSum, 0);
@@ -461,8 +461,15 @@ exports.default = {
             this.$emit('purchased-clicked', row);
         },
         moveAmountClicked: function moveAmountClicked(row, dateTo) {
-            var dateFrom = moment(dateTo).subtract(1, this.dateGroupBy).add(1, "day").format("YYYY-MM-DD");
+            var dateFrom = this.getDateFrom(dateTo);
             this.$emit('move-amount-clicked', row, dateFrom, dateTo);
+        },
+        getDateFrom: function getDateFrom(dateTo) {
+            if (this.dateGroupBy === "month") {
+                return moment(dateTo).startOf("month").format("YYYY-MM-DD");
+            } else {
+                return moment(dateTo).subtract(1, "week").add(1, "day").format("YYYY-MM-DD");
+            }
         }
     }
 };

--- a/vue_stock_forecast/static/src/js/StockForecastReport.js
+++ b/vue_stock_forecast/static/src/js/StockForecastReport.js
@@ -267,8 +267,8 @@ var StockForecastReport = AbstractAction.extend(ControlPanelMixin, {
         var dayAfterDateTo = moment(dateTo).add(1, "day").format("YYYY-MM-DD");
         var domain = [
             ["state", "not in", ["done", "cancel"]],
-            ["date_expected", ">=", dateFrom],
-            ["date_expected", "<", dayAfterDateTo],
+            ["date_expected", ">=", this.toUTC(dateFrom)],
+            ["date_expected", "<", this.toUTC(dayAfterDateTo)],
         ];
 
         if(row.productId){
@@ -297,6 +297,9 @@ var StockForecastReport = AbstractAction.extend(ControlPanelMixin, {
             domain,
         });
     },
+    toUTC(date) {
+        return moment(date).utc().format("YYYY-MM-DD HH:mm:ss")
+    },
     /**
      * Get the domain related to locations used for filtering stock moves.
      *
@@ -315,9 +318,13 @@ var StockForecastReport = AbstractAction.extend(ControlPanelMixin, {
             domain.push(["location_dest_id.usage", "=", "internal"]);
         }
         else{
-            domain.push("|");
-            domain.push(["location_id.usage", "=", "internal"]);
-            domain.push(["location_dest_id.usage", "=", "internal"]);
+            domain.push("|"),
+            domain.push("&"),
+            domain.push(["location_id.usage", "!=", "internal"]),
+            domain.push(["location_dest_id.usage", "=", "internal"]),
+            domain.push("&"),
+            domain.push(["location_id.usage", "=", "internal"]),
+            domain.push(["location_dest_id.usage", "!=", "internal"]),
         }
         return domain;
     },

--- a/vue_stock_forecast/static/src/js/StockForecastTable.vue
+++ b/vue_stock_forecast/static/src/js/StockForecastTable.vue
@@ -120,10 +120,10 @@ export default {
             var outgoingQty = row.outgoing.filter(movesBeforeDate).reduce(stockMoveSum, 0);
             var stockAtDate = row.currentStock + incomingQty - outgoingQty;
 
-            var dateFrom = moment(dateTo).subtract(1, this.dateGroupBy).format("YYYY-MM-DD");
+            var dateFrom = this.getDateFrom(dateTo)
 
             function movesAtDate(move) {
-                return dateFrom < move.date && move.date <= dateTo
+                return dateFrom <= move.date && move.date <= dateTo
             }
             var incomingQtyAtDate = row.incoming.filter(movesAtDate).reduce(stockMoveSum, 0);
             var outgoingQtyAtDate = row.outgoing.filter(movesAtDate).reduce(stockMoveSum, 0);
@@ -168,9 +168,17 @@ export default {
             this.$emit('purchased-clicked', row);
         },
         moveAmountClicked(row, dateTo){
-            var dateFrom = moment(dateTo).subtract(1, this.dateGroupBy).add(1, "day").format("YYYY-MM-DD");
+            var dateFrom = this.getDateFrom(dateTo)
             this.$emit('move-amount-clicked', row, dateFrom, dateTo);
         },
+        getDateFrom(dateTo) {
+            if (this.dateGroupBy === "month") {
+                return moment(dateTo).startOf("month").format("YYYY-MM-DD");
+            }
+            else {
+                return moment(dateTo).subtract(1, "week").add(1, "day").format("YYYY-MM-DD");
+            }
+        }
     },
 };
 


### PR DESCRIPTION
Properly convert the date range to UTC when filtering stock moves.

Exclude stock moves that are not incoming or outgoing.