### PR TITLE
TA#36017 Refactor stock forecast table based on native html

### DIFF
--- a/vue_stock_forecast/static/dist/vueStockForecast.js
+++ b/vue_stock_forecast/static/dist/vueStockForecast.js
@@ -353,6 +353,21 @@ Object.defineProperty(exports, "__esModule", {
 //
 //
 //
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
 
 
 exports.default = {
@@ -386,16 +401,36 @@ exports.default = {
             default: true
         }
     },
-    computed: {
-        dateGroups: function dateGroups() {
-            return getDateRange(this.dateFrom, this.dateTo, this.dateGroupBy || "month");
+    data: function data() {
+        return {
+            dateGroups: []
+        };
+    },
+    mounted: function mounted() {
+        this.computeDateGroups();
+    },
+
+    watch: {
+        dateFrom: function dateFrom() {
+            this.computeDateGroups();
         },
+        dateTo: function dateTo() {
+            this.computeDateGroups();
+        },
+        dateGroupBy: function dateGroupBy() {
+            this.computeDateGroups();
+        }
+    },
+    computed: {
         rowGroupLabel: function rowGroupLabel() {
             var label = this.rowGroupBy === "product" ? "Product" : "Product Category";
             return this.translate(label);
         }
     },
     methods: {
+        computeDateGroups: function computeDateGroups() {
+            this.dateGroups = makeDateGroups(this.dateFrom, this.dateTo, this.dateGroupBy || "month");
+        },
         productHasMovesAtDate: function productHasMovesAtDate(row, dateTo) {
             var dateFrom = moment(dateTo).subtract(1, this.dateGroupBy || "month").format("YYYY-MM-DD");
             function movesAtDate(move) {
@@ -477,7 +512,7 @@ exports.default = {
 
 var nextGroupKey = 1;
 
-function getDateRange(dateFrom, dateTo, dateGroupBy) {
+function makeDateGroups(dateFrom, dateTo, dateGroupBy) {
     var dateRange = [];
     var currentMoment = moment(dateFrom);
     var momentTo = moment(dateTo);
@@ -807,246 +842,208 @@ var render = function() {
   var _vm = this
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
-  return _c(
-    "div",
-    { staticClass: "stock-forecast-table" },
-    [
-      _c(
-        "el-table",
-        {
-          attrs: { data: _vm.rows, height: "800", border: "", "row-key": "key" }
-        },
-        [
-          _c("el-table-column", {
-            attrs: {
-              label: _vm.rowGroupLabel,
-              width: "300",
-              fixed: _vm.firstColumnFixed
-            },
-            scopedSlots: _vm._u([
-              {
-                key: "default",
-                fn: function(scope) {
-                  return [
-                    _c("div", [
-                      _vm._v(
-                        "\n          " + _vm._s(scope.row.label) + "\n        "
-                      )
-                    ])
-                  ]
-                }
-              }
-            ])
-          }),
-          _vm._v(" "),
-          _c("el-table-column", {
-            attrs: {
-              label: _vm.translate("Stock "),
-              width: "160",
-              align: "center"
-            },
-            scopedSlots: _vm._u([
-              {
-                key: "default",
-                fn: function(scope) {
-                  return [
-                    scope.row.currentStock
-                      ? _c(
-                          "div",
-                          {
-                            staticClass: "stock-forecast-table__link",
-                            on: {
-                              click: function($event) {
-                                _vm.currentStockClicked(scope.row)
-                              }
-                            }
-                          },
-                          [
-                            _vm._v(
-                              "\n          " +
-                                _vm._s(_vm.displayCurrentStock(scope.row)) +
-                                "\n        "
-                            )
-                          ]
-                        )
-                      : _c("div", [_vm._v("0")])
-                  ]
-                }
-              }
-            ])
-          }),
-          _vm._v(" "),
-          _c("el-table-column", {
-            attrs: {
-              label: _vm.translate("Reserved "),
-              width: "160",
-              align: "center"
-            },
-            scopedSlots: _vm._u([
-              {
-                key: "default",
-                fn: function(scope) {
-                  return [
-                    _c("div", [
-                      _vm._v(
-                        "\n          " +
-                          _vm._s(_vm.displayReservedStock(scope.row)) +
-                          "\n        "
-                      )
-                    ])
-                  ]
-                }
-              }
-            ])
-          }),
-          _vm._v(" "),
-          _c("el-table-column", {
-            attrs: {
-              label: _vm.translate("Available "),
-              width: "160",
-              align: "center"
-            },
-            scopedSlots: _vm._u([
-              {
-                key: "default",
-                fn: function(scope) {
-                  return [
-                    _c("div", [
-                      _vm._v(
-                        "\n          " +
-                          _vm._s(_vm.displayAvailableStock(scope.row)) +
-                          "\n        "
-                      )
-                    ])
-                  ]
-                }
-              }
-            ])
-          }),
-          _vm._v(" "),
-          _c("el-table-column", {
-            attrs: {
-              label: _vm.translate("Min / Max "),
-              width: "160",
-              align: "center"
-            },
-            scopedSlots: _vm._u([
-              {
-                key: "default",
-                fn: function(scope) {
-                  return [
-                    _c(
-                      "div",
-                      {
-                        staticClass: "stock-forecast-table__link",
-                        on: {
-                          click: function($event) {
-                            _vm.minMaxClicked(scope.row)
-                          }
-                        }
-                      },
-                      [
-                        _vm._v(
-                          "\n          " +
-                            _vm._s(_vm.displayMinMax(scope.row)) +
-                            "\n        "
-                        )
-                      ]
-                    )
-                  ]
-                }
-              }
-            ])
-          }),
-          _vm._v(" "),
-          _c("el-table-column", {
-            attrs: {
-              label: _vm.translate("Quotation "),
-              width: "160",
-              align: "center"
-            },
-            scopedSlots: _vm._u([
-              {
-                key: "default",
-                fn: function(scope) {
-                  return [
-                    _c(
-                      "div",
-                      {
-                        staticClass: "stock-forecast-table__link",
-                        on: {
-                          click: function($event) {
-                            _vm.purchasedClicked(scope.row)
-                          }
-                        }
-                      },
-                      [
-                        _vm._v(
-                          "\n          " +
-                            _vm._s(_vm.displayPurchased(scope.row)) +
-                            "\n        "
-                        )
-                      ]
-                    )
-                  ]
-                }
-              }
-            ])
-          }),
-          _vm._v(" "),
-          _vm._l(_vm.dateGroups, function(dateGroup) {
-            return _c("el-table-column", {
-              key: dateGroup.key,
-              attrs: { label: dateGroup.date, width: "160", align: "center" },
-              scopedSlots: _vm._u([
-                {
-                  key: "default",
-                  fn: function(scope) {
-                    return [
-                      _vm.productHasMovesAtDate(scope.row, dateGroup.date)
-                        ? _c(
-                            "div",
-                            {
-                              staticClass:
-                                "stock-forecast-table__link stock-forecast-table__amount",
-                              on: {
-                                click: function($event) {
-                                  _vm.moveAmountClicked(
-                                    scope.row,
-                                    dateGroup.date
-                                  )
-                                }
-                              }
-                            },
-                            [
-                              _vm._v(
-                                "\n          " +
-                                  _vm._s(
-                                    _vm.getStockValue(scope.row, dateGroup.date)
-                                  ) +
-                                  "\n        "
-                              )
-                            ]
-                          )
-                        : _c("div", [
-                            _vm._v(
-                              _vm._s(
-                                _vm.getStockValue(scope.row, dateGroup.date)
-                              )
-                            )
-                          ])
-                    ]
-                  }
-                }
+  return _c("div", { staticClass: "stock-forecast-table" }, [
+    _c("table", [
+      _c("thead", [
+        _c(
+          "tr",
+          [
+            _c("th", [
+              _vm._v(
+                "\n                    " +
+                  _vm._s(_vm.rowGroupLabel) +
+                  "\n                "
+              )
+            ]),
+            _vm._v(" "),
+            _c("th", [
+              _vm._v(
+                "\n                    " +
+                  _vm._s(_vm.translate("Stock ")) +
+                  "\n                "
+              )
+            ]),
+            _vm._v(" "),
+            _c("th", [
+              _vm._v(
+                "\n                    " +
+                  _vm._s(_vm.translate("Reserved ")) +
+                  "\n                "
+              )
+            ]),
+            _vm._v(" "),
+            _c("th", [
+              _vm._v(
+                "\n                    " +
+                  _vm._s(_vm.translate("Available ")) +
+                  "\n                "
+              )
+            ]),
+            _vm._v(" "),
+            _c("th", [
+              _vm._v(
+                "\n                    " +
+                  _vm._s(_vm.translate("Min / Max ")) +
+                  "\n                "
+              )
+            ]),
+            _vm._v(" "),
+            _c("th", [
+              _vm._v(
+                "\n                    " +
+                  _vm._s(_vm.translate("Quotation ")) +
+                  "\n                "
+              )
+            ]),
+            _vm._v(" "),
+            _vm._l(_vm.dateGroups, function(dateGroup) {
+              return _c("th", { key: dateGroup.date }, [
+                _vm._v(
+                  "\n                    " +
+                    _vm._s(dateGroup.date) +
+                    "\n                "
+                )
               ])
             })
-          })
-        ],
-        2
+          ],
+          2
+        )
+      ]),
+      _vm._v(" "),
+      _c(
+        "tbody",
+        _vm._l(_vm.rows, function(row) {
+          return _c(
+            "tr",
+            { key: row.key },
+            [
+              _c("td", [
+                _vm._v(
+                  "\n                    " +
+                    _vm._s(row.label) +
+                    "\n                "
+                )
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                row.currentStock
+                  ? _c(
+                      "div",
+                      {
+                        staticClass: "stock-forecast-table__link",
+                        on: {
+                          click: function($event) {
+                            _vm.currentStockClicked(row)
+                          }
+                        }
+                      },
+                      [
+                        _vm._v(
+                          "\n                        " +
+                            _vm._s(_vm.displayCurrentStock(row)) +
+                            "\n                    "
+                        )
+                      ]
+                    )
+                  : _c("div", [_vm._v("0")])
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _vm._v(
+                  "\n                    " +
+                    _vm._s(_vm.displayReservedStock(row)) +
+                    "\n                "
+                )
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _vm._v(
+                  "\n                    " +
+                    _vm._s(_vm.displayAvailableStock(row)) +
+                    "\n                "
+                )
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _c(
+                  "div",
+                  {
+                    staticClass: "stock-forecast-table__link",
+                    on: {
+                      click: function($event) {
+                        _vm.minMaxClicked(row)
+                      }
+                    }
+                  },
+                  [
+                    _vm._v(
+                      "\n                        " +
+                        _vm._s(_vm.displayMinMax(row)) +
+                        "\n                    "
+                    )
+                  ]
+                )
+              ]),
+              _vm._v(" "),
+              _c("td", [
+                _c(
+                  "div",
+                  {
+                    staticClass: "stock-forecast-table__link",
+                    on: {
+                      click: function($event) {
+                        _vm.purchasedClicked(row)
+                      }
+                    }
+                  },
+                  [
+                    _vm._v(
+                      "\n                        " +
+                        _vm._s(_vm.displayPurchased(row)) +
+                        "\n                    "
+                    )
+                  ]
+                )
+              ]),
+              _vm._v(" "),
+              _vm._l(_vm.dateGroups, function(dateGroup) {
+                return _c("td", { key: dateGroup.key }, [
+                  _vm.productHasMovesAtDate(row, dateGroup.date)
+                    ? _c(
+                        "div",
+                        {
+                          staticClass:
+                            "stock-forecast-table__link stock-forecast-table__amount",
+                          on: {
+                            click: function($event) {
+                              _vm.moveAmountClicked(row, dateGroup.date)
+                            }
+                          }
+                        },
+                        [
+                          _vm._v(
+                            "\n                        " +
+                              _vm._s(_vm.getStockValue(row, dateGroup.date)) +
+                              "\n                    "
+                          )
+                        ]
+                      )
+                    : _c("div", [
+                        _vm._v(
+                          "\n                        " +
+                            _vm._s(_vm.getStockValue(row, dateGroup.date)) +
+                            "\n                    "
+                        )
+                      ])
+                ])
+              })
+            ],
+            2
+          )
+        })
       )
-    ],
-    1
-  )
+    ])
+  ])
 }
 var staticRenderFns = []
 render._withStripped = true

--- a/vue_stock_forecast/static/src/css/stock_forecast.css
+++ b/vue_stock_forecast/static/src/css/stock_forecast.css
@@ -1,6 +1,5 @@
 .stock-forecast-report {
-    margin: 8px;
-    max-width: 100vw;
+    width: 100vw;
 }
 
 .stock-forecast-report .el-select{
@@ -11,7 +10,16 @@
     min-width: 150px;
 }
 
+.stock-forecast-table {
+    overflow-x: scroll;
+    max-width: 100%;
+    overflow-y: scroll;
+    max-height: 60vh;
+}
+
 .stock-forecast-table table {
+    background-color: white;
+    table-layout: fixed;
     width: 100%;
 }
 
@@ -26,4 +34,28 @@
 
 .stock-forecast-table__amount {
 	white-space: nowrap;
+}
+
+.stock-forecast-table th:first-child {
+    width: 300px;
+    text-align: left;
+    padding-left: 8px;
+}
+
+.stock-forecast-table th {
+    width: 120px;
+    text-align: center;
+    height: 50px;
+    color: #909399;
+}
+
+
+.stock-forecast-table td:first-child {
+    text-align: left;
+    padding-left: 8px;
+}
+
+.stock-forecast-table td {
+    text-align: center;
+    height: 50px;
 }

--- a/vue_stock_forecast/static/src/js/StockForecastReport.js
+++ b/vue_stock_forecast/static/src/js/StockForecastReport.js
@@ -289,7 +289,7 @@ var StockForecastReport = AbstractAction.extend(ControlPanelMixin, {
             domain.push(["product_id.uom_id", "=", row.uomId]);
         }
 
-        domain.concat(this.getStockMoveLocationDomain());
+        domain = domain.concat(this.getStockMoveLocationDomain());
 
         var actionName = (
             _t("Stock Moves ({date_from} to {date_to})")

--- a/vue_stock_forecast/static/src/js/StockForecastTable.vue
+++ b/vue_stock_forecast/static/src/js/StockForecastTable.vue
@@ -1,61 +1,76 @@
 <template>
-  <div class="stock-forecast-table">
-    <el-table :data="rows" height="800" border row-key="key">
-      <el-table-column :label="rowGroupLabel" width="300" :fixed="firstColumnFixed">
-        <template slot-scope="scope">
-          <div>
-            {{ scope.row.label }}
-          </div>
-        </template>
-      </el-table-column>
-      <el-table-column :label="translate('Stock ')" width="160" align="center">
-        <template slot-scope="scope">
-          <div class="stock-forecast-table__link" @click="currentStockClicked(scope.row)" v-if="scope.row.currentStock">
-            {{ displayCurrentStock(scope.row) }}
-          </div>
-          <div v-else>0</div>
-        </template>
-      </el-table-column>
-      <el-table-column :label="translate('Reserved ')" width="160" align="center">
-        <template slot-scope="scope">
-          <div>
-            {{ displayReservedStock(scope.row) }}
-          </div>
-        </template>
-      </el-table-column>
-      <el-table-column :label="translate('Available ')" width="160" align="center">
-        <template slot-scope="scope">
-          <div>
-            {{ displayAvailableStock(scope.row) }}
-          </div>
-        </template>
-      </el-table-column>
-      <el-table-column :label="translate('Min / Max ')" width="160" align="center">
-        <template slot-scope="scope">
-          <div class="stock-forecast-table__link" @click="minMaxClicked(scope.row)">
-            {{ displayMinMax(scope.row) }}
-          </div>
-        </template>
-      </el-table-column>
-      <el-table-column :label="translate('Quotation ')" width="160" align="center">
-        <template slot-scope="scope">
-          <div class="stock-forecast-table__link" @click="purchasedClicked(scope.row)">
-            {{ displayPurchased(scope.row) }}
-          </div>
-        </template>
-      </el-table-column>
-      <el-table-column v-for="dateGroup in dateGroups" :key="dateGroup.key" :label="dateGroup.date" width="160" align="center">
-        <template slot-scope="scope">
-          <div class="stock-forecast-table__link stock-forecast-table__amount"
-            @click="moveAmountClicked(scope.row, dateGroup.date)"
-            v-if="productHasMovesAtDate(scope.row, dateGroup.date)">
-            {{ getStockValue(scope.row, dateGroup.date) }}
-          </div>
-          <div v-else>{{ getStockValue(scope.row, dateGroup.date) }}</div>
-        </template>
-      </el-table-column>
-    </el-table>
-  </div>
+<div class="stock-forecast-table">
+    <table>
+        <thead>
+            <tr>
+                <th>
+                    {{ rowGroupLabel }}
+                </th>
+                <th>
+                    {{ translate('Stock ') }}
+                </th>
+                <th>
+                    {{ translate('Reserved ') }}
+                </th>
+                <th>
+                    {{ translate('Available ') }}
+                </th>
+                <th>
+                    {{ translate('Min / Max ') }}
+                </th>
+                <th>
+                    {{ translate('Quotation ') }}
+                </th>
+                <th v-for="dateGroup in dateGroups" :key="dateGroup.date">
+                    {{ dateGroup.date }}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr v-for="row in rows" :key="row.key">
+                <td>
+                    {{ row.label }}
+                </td>
+                <td>
+                    <div
+                        class="stock-forecast-table__link"
+                        @click="currentStockClicked(row)"
+                        v-if="row.currentStock"
+                    >
+                        {{ displayCurrentStock(row) }}
+                    </div>
+                    <div v-else>0</div>
+                </td>
+                <td>
+                    {{ displayReservedStock(row) }}
+                </td>
+                <td>
+                    {{ displayAvailableStock(row) }}
+                </td>
+                <td>
+                    <div class="stock-forecast-table__link" @click="minMaxClicked(row)">
+                        {{ displayMinMax(row) }}
+                    </div>
+                </td>
+                <td>
+                    <div class="stock-forecast-table__link" @click="purchasedClicked(row)">
+                        {{ displayPurchased(row) }}
+                    </div>
+                </td>
+                <td v-for="dateGroup in dateGroups" :key="dateGroup.key">
+                    <div class="stock-forecast-table__link stock-forecast-table__amount"
+                        @click="moveAmountClicked(row, dateGroup.date)"
+                        v-if="productHasMovesAtDate(row, dateGroup.date)">
+                        {{ getStockValue(row, dateGroup.date) }}
+                    </div>
+                    <div v-else>
+                        {{ getStockValue(row, dateGroup.date) }}
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 </template>
 
 <script>
@@ -91,16 +106,35 @@ export default {
             default: true,
         },
     },
-    computed: {
-        dateGroups(){
-            return getDateRange(this.dateFrom, this.dateTo, this.dateGroupBy || "month");
+    data() {
+        return {
+            dateGroups: []
+        }
+    },
+    mounted() {
+        this.computeDateGroups()
+    },
+    watch: {
+        dateFrom() {
+            this.computeDateGroups()
         },
+        dateTo() {
+            this.computeDateGroups()
+        },
+        dateGroupBy() {
+            this.computeDateGroups()
+        },
+    },
+    computed: {
         rowGroupLabel(){
             var label = this.rowGroupBy === "product" ? "Product" : "Product Category";
             return this.translate(label);
         },
     },
     methods: {
+        computeDateGroups(){
+            this.dateGroups = makeDateGroups(this.dateFrom, this.dateTo, this.dateGroupBy || "month");
+        },
         productHasMovesAtDate(row, dateTo){
             var dateFrom = moment(dateTo).subtract(1, this.dateGroupBy || "month").format("YYYY-MM-DD");
             function movesAtDate(move) {
@@ -184,7 +218,7 @@ export default {
 
 let nextGroupKey = 1
 
-function getDateRange(dateFrom, dateTo, dateGroupBy){
+function makeDateGroups(dateFrom, dateTo, dateGroupBy){
     var dateRange = [];
     var currentMoment = moment(dateFrom);
     var momentTo = moment(dateTo);


### PR DESCRIPTION
The table widget of element-ui bugs when changing the columns dynamically.
Use native tables in order to prevent such bug.